### PR TITLE
Make hero text grey

### DIFF
--- a/style.css
+++ b/style.css
@@ -76,13 +76,13 @@ body::before {
     font-size: clamp(1rem, 3vw + 0.2rem, 3.5rem);
     font-weight: 700;
     margin-bottom: 0.25rem;
-    color: #cccccc;
+    color: #999999;
 }
 
 .main-text .focus {
     font-size: clamp(0.9rem, 2.5vw + 0.2rem, 3rem);
     font-weight: 600;
-    color: #bbbbbb;
+    color: #999999;
 }
 
 /* Timeline Footer */

--- a/style.css
+++ b/style.css
@@ -74,7 +74,7 @@ body::before {
 
 .main-text .name {
     font-size: clamp(1rem, 3vw + 0.2rem, 3.5rem);
-    font-weight: 700;
+    font-weight: 600;
     margin-bottom: 0.25rem;
     color: #999999;
 }


### PR DESCRIPTION
## Summary
- adjust colors for `.main-text .name` and `.focus` so the hero text matches in grey

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fad52a6c4832982455f313ffcab22