### PR TITLE
Set light mode as default

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         data-website-id="778f1b86-bd55-4a72-ae92-56d50467d7d5"></script>
 </head>
 
-<body>
+<body class="light-mode">
     <nav class="top-nav">
         <div class="nav-left">
             <a href="#">Career</a>
@@ -37,7 +37,7 @@
             <a href="https://www.linkedin.com/in/jzheng39/" target="_blank">LinkedIn</a>
             <a href="https://github.com/M1ght1203" target="_blank">GitHub</a>
             <label class="theme-toggle">
-                <input type="checkbox" onclick="toggleTheme()" id="themeToggle" aria-label="Toggle theme">
+                <input type="checkbox" onclick="toggleTheme()" id="themeToggle" aria-label="Toggle theme" checked>
                 <span class="switch">
                     <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 0010.08 9.79z" />
@@ -153,7 +153,7 @@
         <a href="https://www.linkedin.com/in/jzheng39/" target="_blank">LinkedIn</a>
         <a href="https://github.com/M1ght1203" target="_blank">GitHub</a>
         <label class="theme-toggle">
-            <input type="checkbox" onclick="toggleTheme()" id="themeToggleMobile" aria-label="Toggle theme">
+            <input type="checkbox" onclick="toggleTheme()" id="themeToggleMobile" aria-label="Toggle theme" checked>
             <span class="switch">
                 <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 0010.08 9.79z" />
@@ -204,7 +204,12 @@
         }
 
         const savedTheme = localStorage.getItem('theme');
-        if (savedTheme === 'light') {
+        if (savedTheme === 'dark') {
+            document.body.classList.remove('light-mode');
+            document.querySelectorAll('.theme-toggle input').forEach(input => {
+                input.checked = false;
+            });
+        } else {
             document.body.classList.add('light-mode');
             document.querySelectorAll('.theme-toggle input').forEach(input => {
                 input.checked = true;


### PR DESCRIPTION
## Summary
- default body class is now `light-mode`
- checkboxes start checked for light theme
- script applies light theme unless stored theme is dark

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684051363c64832994ce726c25b36408