### PR TITLE
Add Career section

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,17 +75,25 @@
 
             <div class="career-entry">
                 <h3>Software Engineer Intern</h3>
-                <p class="company">Accenture · Summer 2024</p>
+                <p class="company">L3Harris Technologies · Jun 2024 – Aug 2024 · Rochester, NY</p>
                 <p class="description">
-                    Worked on automation and full-stack tools to improve internal workflows. Built dashboards and deployed CI/CD pipelines.
+                    Automated sales pricing with a C# WPF tool, aligning solutions with business goals and resolving 40+ tickets on a scrum team.
                 </p>
             </div>
 
             <div class="career-entry">
-                <h3>Tech Intern</h3>
-                <p class="company">Bank of America · Fall 2023</p>
+                <h3>Assistant Manager</h3>
+                <p class="company">C U Plastic LLC · May 2021 – May 2024 · Rochelle, IL</p>
                 <p class="description">
-                    Assisted in refactoring legacy systems and migrating to microservices using Spring Boot and Docker.
+                    Improved cross-department workflows by 20% and cut truck-loading times by 25% through data-driven planning and staging strategies.
+                </p>
+            </div>
+
+            <div class="career-entry">
+                <h3>Software Engineer Intern</h3>
+                <p class="company">L3Harris Technologies · May 2025 – Jul 2025 · Rochester, NY</p>
+                <p class="description">
+                    Building an internal CRM in C#/.NET with ExpressSQL, expanding last summer's pricing tool to streamline operations.
                 </p>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -76,25 +76,33 @@
             <div class="career-entry">
                 <h3>Software Engineer Intern</h3>
                 <p class="company">L3Harris Technologies · Jun 2024 – Aug 2024 · Rochester, NY</p>
-                <p class="description">
-                    Automated sales pricing with a C# WPF tool, aligning solutions with business goals and resolving 40+ tickets on a scrum team.
-                </p>
+                <ul class="description">
+                    <li>Increased time efficiency by 98% through a C# WPF pricing automation tool.</li>
+                    <li>Aligned pricing with business goals using stakeholder analysis and data‑driven decisions.</li>
+                    <li>Resolved more than 43 tickets in nine weeks as part of a six‑member scrum team.</li>
+                </ul>
+                <p class="tech">Skills: C#, WPF, .NET, Agile</p>
             </div>
 
             <div class="career-entry">
                 <h3>Assistant Manager</h3>
                 <p class="company">C U Plastic LLC · May 2021 – May 2024 · Rochelle, IL</p>
-                <p class="description">
-                    Improved cross-department workflows by 20% and cut truck-loading times by 25% through data-driven planning and staging strategies.
-                </p>
+                <ul class="description">
+                    <li>Boosted organizational efficiency by 20% with data‑driven cross‑department workflows.</li>
+                    <li>Enhanced productivity by 15% and improved documentation via collaborative planning.</li>
+                    <li>Reduced truck‑loading times by 25% with a new staging strategy.</li>
+                </ul>
+                <p class="tech">Skills: Data Analysis, Workflow Optimization, Logistics</p>
             </div>
 
             <div class="career-entry">
                 <h3>Software Engineer Intern</h3>
                 <p class="company">L3Harris Technologies · May 2025 – Jul 2025 · Rochester, NY</p>
-                <p class="description">
-                    Building an internal CRM in C#/.NET with ExpressSQL, expanding last summer's pricing tool to streamline operations.
-                </p>
+                <ul class="description">
+                    <li>Building a custom internal CRM based on last summer's pricing tool.</li>
+                    <li>Using ExpressSQL with C#/.NET to streamline and automate operations.</li>
+                </ul>
+                <p class="tech">Skills: C#, .NET, ExpressSQL</p>
             </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 <body class="light-mode">
     <nav class="top-nav">
         <div class="nav-left">
-            <a href="#">Career</a>
+            <a href="#career">Career</a>
             <a href="#projects">Projects</a>
             <a href="#skills">Skills</a>
             <a href="#">Organizations</a>
@@ -68,6 +68,26 @@
                         stroke-linejoin="round" />
                 </svg>
             </a>
+        </section>
+
+        <section id="career">
+            <h2 class="section-title">Career</h2>
+
+            <div class="career-entry">
+                <h3>Software Engineer Intern</h3>
+                <p class="company">Accenture · Summer 2024</p>
+                <p class="description">
+                    Worked on automation and full-stack tools to improve internal workflows. Built dashboards and deployed CI/CD pipelines.
+                </p>
+            </div>
+
+            <div class="career-entry">
+                <h3>Tech Intern</h3>
+                <p class="company">Bank of America · Fall 2023</p>
+                <p class="description">
+                    Assisted in refactoring legacy systems and migrating to microservices using Spring Boot and Docker.
+                </p>
+            </div>
         </section>
 
         <section id="projects" class="projects-section">
@@ -146,7 +166,7 @@
     <div class="mobile-backdrop" onclick="toggleMenu()"></div>
 
     <div class="mobile-menu" id="mobileMenu">
-        <a href="#">Career</a>
+        <a href="#career">Career</a>
         <a href="#projects">Projects</a>
         <a href="#skills">Skills</a>
         <a href="#">Organizations</a>

--- a/style.css
+++ b/style.css
@@ -115,7 +115,6 @@ body::before {
     opacity: 0;
     transform: translateY(20px);
     animation: fadeInUp 0.6s ease-out forwards;
-    text-align: center;
 }
 
 .career-entry h3 {
@@ -134,8 +133,6 @@ body::before {
     color: var(--footer-text);
     line-height: 1.6;
     list-style-type: disc;
-    display: inline-block;
-    text-align: left;
     margin-left: 1.25rem;
     margin-bottom: 0.5rem;
 }

--- a/style.css
+++ b/style.css
@@ -132,6 +132,14 @@ body::before {
     font-size: 0.95rem;
     color: var(--footer-text);
     line-height: 1.6;
+    list-style-type: disc;
+    margin-left: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.career-entry .tech {
+    font-size: 0.9rem;
+    color: var(--secondary-text);
 }
 
 .projects-section {

--- a/style.css
+++ b/style.css
@@ -97,6 +97,43 @@ body::before {
     animation: bounce 1.2s infinite;
 }
 
+#career {
+    padding: 4rem 2rem;
+    max-width: 900px;
+    margin: auto;
+}
+
+.section-title {
+    font-size: 2rem;
+    font-weight: 800;
+    margin-bottom: 2rem;
+    text-align: center;
+}
+
+.career-entry {
+    margin-bottom: 2rem;
+    opacity: 0;
+    transform: translateY(20px);
+    animation: fadeInUp 0.6s ease-out forwards;
+}
+
+.career-entry h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.career-entry .company {
+    font-size: 1rem;
+    color: var(--secondary-text);
+    margin: 0.25rem 0 0.75rem;
+}
+
+.career-entry .description {
+    font-size: 0.95rem;
+    color: var(--footer-text);
+    line-height: 1.6;
+}
+
 .projects-section {
     padding-top: 3rem;
 }

--- a/style.css
+++ b/style.css
@@ -115,6 +115,7 @@ body::before {
     opacity: 0;
     transform: translateY(20px);
     animation: fadeInUp 0.6s ease-out forwards;
+    text-align: center;
 }
 
 .career-entry h3 {
@@ -133,6 +134,8 @@ body::before {
     color: var(--footer-text);
     line-height: 1.6;
     list-style-type: disc;
+    display: inline-block;
+    text-align: left;
     margin-left: 1.25rem;
     margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- feature: add a new Career section above Projects
- style: add matching styles for Career entries
- navigation: link to `#career` from desktop and mobile menus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840591a0e108329af638a81a7187e75