### PR TITLE
Fix right spacing for career cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -135,6 +135,7 @@ body::before {
     list-style-type: disc;
     list-style-position: inside;
     padding-left: 0;
+    padding-right: 0;
     margin-left: 0;
     margin-bottom: 0.5rem;
 }

--- a/style.css
+++ b/style.css
@@ -133,7 +133,8 @@ body::before {
     color: var(--footer-text);
     line-height: 1.6;
     list-style-type: disc;
-    padding-left: 1.25rem;
+    list-style-position: inside;
+    padding-left: 0;
     margin-left: 0;
     margin-bottom: 0.5rem;
 }

--- a/style.css
+++ b/style.css
@@ -133,7 +133,8 @@ body::before {
     color: var(--footer-text);
     line-height: 1.6;
     list-style-type: disc;
-    margin-left: 1.25rem;
+    padding-left: 1.25rem;
+    margin-left: 0;
     margin-bottom: 0.5rem;
 }
 

--- a/style.css
+++ b/style.css
@@ -99,7 +99,7 @@ body::before {
 
 #career {
     padding: 4rem 2rem;
-    max-width: 900px;
+    width: fit-content;
     margin: auto;
 }
 
@@ -338,7 +338,7 @@ body::before {
     transition: transform 0.2s ease;
 }
 
-.theme-toggle input:checked + .switch::before {
+.theme-toggle input:checked+.switch::before {
     transform: translateX(26px);
 }
 
@@ -507,9 +507,12 @@ body::before {
 }
 
 @keyframes bounce {
-    0%, 100% {
+
+    0%,
+    100% {
         transform: translateY(0);
     }
+
     50% {
         transform: translateY(5px);
     }


### PR DESCRIPTION
## Summary
- reduce left margin on career description lists so cards stay centered

## Testing
- `htmlhint index.html`
- `stylelint "**/*.css"` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_684060fecfc08329a6a276999d66147c