### PR TITLE
Add carousel for projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,16 +276,28 @@
         // Projects Carousel
         const carousel = document.querySelector('.projects-carousel');
         const slides = document.querySelectorAll('.projects-carousel .project-item');
-        let currentSlide = 0;
+        let currentSlide = 1;
         const slideInterval = 5000; // milliseconds each slide stays
 
-        function showSlide(index) {
-            carousel.style.transform = `translateX(-${index * 100}%)`;
+        function updateSlides() {
+            slides.forEach((slide) => {
+                slide.classList.remove('prev', 'active', 'next');
+            });
+
+            const prev = (currentSlide - 1 + slides.length) % slides.length;
+            const next = (currentSlide + 1) % slides.length;
+
+            slides[prev].classList.add('prev');
+            slides[currentSlide].classList.add('active');
+            slides[next].classList.add('next');
+
+            carousel.style.transform = `translateX(-${(currentSlide - 1) * 33.333}%)`;
         }
 
+        updateSlides();
         setInterval(() => {
             currentSlide = (currentSlide + 1) % slides.length;
-            showSlide(currentSlide);
+            updateSlides();
         }, slideInterval);
     </script>
 

--- a/style.css
+++ b/style.css
@@ -168,16 +168,22 @@ body::before {
 
 .projects-carousel {
     display: flex;
+    align-items: center;
     transition: transform 0.6s ease-in-out;
 }
 
 .project-item {
-    flex: 0 0 100%;
+    flex: 0 0 33.333%;
     text-align: center;
     padding: 1rem;
     font-size: clamp(0.7rem, 0.9vw, 0.8rem);
     color: var(--footer-text);
     line-height: 1.4;
+    background-color: var(--button-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    margin: 0 0.5rem;
+    transition: transform 0.6s ease, opacity 0.6s ease;
 }
 
 .project-item span {
@@ -185,6 +191,17 @@ body::before {
     margin-top: 0.25rem;
     font-size: clamp(0.6rem, 0.8vw, 0.7rem);
     color: var(--footer-span);
+}
+
+.project-item.prev,
+.project-item.next {
+    transform: scale(0.85);
+    opacity: 0.7;
+}
+
+.project-item.active {
+    transform: scale(1.1);
+    opacity: 1;
 }
 
 /* Main Section */


### PR DESCRIPTION
## Summary
- redesign projects section into an auto-sliding carousel
- style new carousel and items
- implement JavaScript to cycle through projects every few seconds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852d714cfbc8329bedf3ad1c75fcfdf