### PR TITLE
Fix responsive career title

### DIFF
--- a/style.css
+++ b/style.css
@@ -106,7 +106,7 @@ body::before {
 }
 
 .section-title {
-    font-size: 8rem;
+    font-size: clamp(3rem, 8vw, 8rem);
     font-weight: 800;
     margin-bottom: 2rem;
     text-align: left;


### PR DESCRIPTION
## Summary
- adjust `.section-title` to use a clamp-based font-size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531a555ce4832989bcbccbf0f89cf2