### PR TITLE
Align navbar margin with page

### DIFF
--- a/style.css
+++ b/style.css
@@ -291,7 +291,7 @@ body::before {
     justify-content: space-between;
     align-items: center;
     padding: 1rem 1.5rem;
-    margin: 0;
+    margin: 0 1.5rem;
     background-color: transparent;
     z-index: 1000;
     transition: background-color 0.3s ease;


### PR DESCRIPTION
## Summary
- set left/right margin on the sticky navbar so its sides line up with the page content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687167e15b0883299a30a52a1891999a