### PR TITLE
Remove grid background overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,25 +44,6 @@ body {
     --backdrop-bg: rgba(0, 0, 0, 0.4);
 }
 
-body::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-image:
-        linear-gradient(to right, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
-        linear-gradient(to bottom, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
-    background-size: 300px 160px;
-    pointer-events: none;
-    z-index: 0;
-    animation: revealGrid 1.5s ease-out forwards;
-    opacity: 0;
-    mask-image: linear-gradient(135deg, black 40%, transparent 100%);
-    mask-size: 200%;
-    mask-position: top left;
-}
 
 .scroll-wrapper {
     padding: 2rem 1.5rem;


### PR DESCRIPTION
## Summary
- deleted `body::before` rule in `style.css` to remove the background grid

## Testing
- `git diff style.css | sed -n '1,40p'`

------
https://chatgpt.com/codex/tasks/task_e_687bb96fa70883298515c8dc8ee63b26