### PR TITLE
Tweak 404 button styling

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="/style.css" />
 </head>
 
 <body class="light-mode not-found-page">
@@ -23,6 +23,13 @@
         </p>
         <a class="not-found__button" href="/">Back to Home</a>
     </main>
+    <script>
+        (function ensureCanonical404() {
+            if (!window.location.pathname.endsWith('/404.html')) {
+                window.location.replace('/404.html');
+            }
+        })();
+    </script>
 </body>
 
 </html>

--- a/404.html
+++ b/404.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="style.css" />
 </head>
 
 <body class="light-mode not-found-page">
@@ -23,13 +23,6 @@
         </p>
         <a class="not-found__button" href="/">Back to Home</a>
     </main>
-    <script>
-        (function ensureCanonical404() {
-            if (!window.location.pathname.endsWith('/404.html')) {
-                window.location.replace('/404.html');
-            }
-        })();
-    </script>
 </body>
 
 </html>

--- a/404.html
+++ b/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page Not Found | Jason Zheng Portfolio</title>
+    <meta name="description" content="The page you are looking for doesn't exist or has been moved." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="style.css" />
+</head>
+
+<body class="light-mode not-found-page">
+    <main class="not-found" role="main">
+        <h1 class="not-found__title">
+            Page<br />
+            Not Found
+        </h1>
+        <p class="not-found__message">
+            The page you are looking for doesn't exist or has been moved.
+        </p>
+        <a class="not-found__button" href="/">Back to Home</a>
+    </main>
+</body>
+
+</html>

--- a/style.css
+++ b/style.css
@@ -677,3 +677,74 @@ body {
         transform: translateY(5px);
     }
 }
+
+/* 404 Page */
+body.not-found-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    background-color: #ffffff;
+    color: #000000;
+    padding: 2rem;
+}
+
+.not-found {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    max-width: 32rem;
+}
+
+.not-found__title {
+    font-size: clamp(3.5rem, 10vw, 6rem);
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: -0.04em;
+}
+
+.not-found__message {
+    font-size: clamp(1rem, 3vw, 1.25rem);
+    color: #4a4a4a;
+}
+
+.not-found__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 2.5rem;
+    background-color: #000000;
+    color: #ffffff;
+    text-decoration: none;
+    font-size: 1rem;
+    font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.not-found__button:hover,
+.not-found__button:focus {
+    background-color: #1a1a1a;
+    transform: translateY(-2px);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.not-found__button:focus {
+    outline: 2px solid #1a1a1a;
+    outline-offset: 4px;
+}
+
+@media (max-width: 480px) {
+    body.not-found-page {
+        padding: 1.5rem;
+    }
+
+    .not-found {
+        gap: 1.25rem;
+    }
+
+    .not-found__button {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated 404.html page with messaging and a call-to-action back to the homepage
- extend the global stylesheet with responsive styles for the new not-found layout
- square off the 404 page call-to-action button to remove rounded corners

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dd7a8cac7c83298ddeb6159d45b2ed