### PR TITLE
Ensure 404 page respects saved theme

### DIFF
--- a/404.html
+++ b/404.html
@@ -23,6 +23,14 @@
         </p>
         <a class="not-found__button" href="/">Back to Home</a>
     </main>
+    <script>
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'dark') {
+            document.body.classList.remove('light-mode');
+        } else {
+            document.body.classList.add('light-mode');
+        }
+    </script>
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -684,8 +684,8 @@ body.not-found-page {
     align-items: center;
     justify-content: center;
     min-height: 100vh;
-    background-color: #ffffff;
-    color: #000000;
+    background-color: var(--bg-color);
+    color: var(--text-color);
     padding: 2rem;
 }
 
@@ -707,7 +707,7 @@ body.not-found-page {
 
 .not-found__message {
     font-size: clamp(1rem, 3vw, 1.25rem);
-    color: #4a4a4a;
+    color: var(--secondary-text);
 }
 
 .not-found__button {
@@ -715,8 +715,8 @@ body.not-found-page {
     align-items: center;
     justify-content: center;
     padding: 0.85rem 2.5rem;
-    background-color: #000000;
-    color: #ffffff;
+    background-color: var(--button-bg);
+    color: var(--text-color);
     text-decoration: none;
     font-size: 1rem;
     font-weight: 600;
@@ -725,13 +725,13 @@ body.not-found-page {
 
 .not-found__button:hover,
 .not-found__button:focus {
-    background-color: #1a1a1a;
+    background-color: var(--button-bg-hover);
     transform: translateY(-2px);
     box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
 }
 
 .not-found__button:focus {
-    outline: 2px solid #1a1a1a;
+    outline: 2px solid var(--text-color);
     outline-offset: 4px;
 }
 


### PR DESCRIPTION
## Summary
- update the 404 page styles to use existing theme variables so colors adapt to light and dark modes
- apply the saved theme preference on load without adding a theme toggle control to the 404 page

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9ca0693c8329b1ae1c0bb0794deb