### PR TITLE
Slow down nav background transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,10 +313,12 @@
         let lastScrollY = window.scrollY;
         let navHideTimeout;
         let navScrollThreshold = 0;
+        let navHideStart = 0;
 
-        function updateNavScrollThreshold() {
+        function updateNavMetrics() {
             const doubledNavHeight = nav.offsetHeight * 2;
             navScrollThreshold = Math.max(doubledNavHeight, 120);
+            navHideStart = Math.max(careerSection.offsetTop - nav.offsetHeight, navScrollThreshold);
         }
 
         heroText.addEventListener('animationend', () => {
@@ -341,10 +343,13 @@
                 nav.classList.remove('hidden');
             }
 
-            if (y > lastScrollY + scrollDelta) {
+            if (y <= navHideStart) {
+                clearTimeout(navHideTimeout);
+                nav.classList.remove('hidden');
+            } else if (y > lastScrollY + scrollDelta) {
                 clearTimeout(navHideTimeout);
                 navHideTimeout = setTimeout(() => {
-                    if (window.scrollY > nav.offsetHeight) {
+                    if (window.scrollY > navHideStart) {
                         nav.classList.add('hidden');
                     }
                 }, navHideDelay);
@@ -364,9 +369,9 @@
             scrollDown.style.transform = `translate(-50%, 0) scale(${scale})`;
         }
 
-        updateNavScrollThreshold();
+        updateNavMetrics();
         window.addEventListener('resize', () => {
-            updateNavScrollThreshold();
+            updateNavMetrics();
             handleScroll();
         });
         window.addEventListener('scroll', handleScroll);

--- a/index.html
+++ b/index.html
@@ -312,6 +312,12 @@
         const navHideDelay = 200;
         let lastScrollY = window.scrollY;
         let navHideTimeout;
+        let navScrollThreshold = 0;
+
+        function updateNavScrollThreshold() {
+            const doubledNavHeight = nav.offsetHeight * 2;
+            navScrollThreshold = Math.max(doubledNavHeight, 120);
+        }
 
         heroText.addEventListener('animationend', () => {
             heroText.style.animation = 'none';
@@ -328,7 +334,7 @@
         function handleScroll() {
             const y = Math.max(window.scrollY, 0);
 
-            if (y > 0) {
+            if (y > navScrollThreshold) {
                 nav.classList.add('scrolled');
             } else {
                 nav.classList.remove('scrolled');
@@ -358,6 +364,11 @@
             scrollDown.style.transform = `translate(-50%, 0) scale(${scale})`;
         }
 
+        updateNavScrollThreshold();
+        window.addEventListener('resize', () => {
+            updateNavScrollThreshold();
+            handleScroll();
+        });
         window.addEventListener('scroll', handleScroll);
         handleScroll();
 

--- a/style.css
+++ b/style.css
@@ -362,7 +362,7 @@ body {
     transform: translate(-50%, 0);
     border: 1px solid transparent;
     backdrop-filter: blur(18px);
-    transition: background-color 0.6s ease, transform 0.3s ease, border-color 0.3s ease;
+    transition: background-color 0.6s ease, transform 0.6s ease-in-out, border-color 0.3s ease;
 }
 
 .top-nav.hidden {

--- a/style.css
+++ b/style.css
@@ -362,7 +362,7 @@ body {
     transform: translate(-50%, 0);
     border: 1px solid transparent;
     backdrop-filter: blur(18px);
-    transition: background-color 0.3s ease, transform 0.3s ease, border-color 0.3s ease;
+    transition: background-color 0.6s ease, transform 0.3s ease, border-color 0.3s ease;
 }
 
 .top-nav.hidden {


### PR DESCRIPTION
## Summary
- lengthen the navbar background-color transition duration for a smoother scroll effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd9eb531448329b9afc415435fa30e