### PR TITLE
Remove navigation bar borders

### DIFF
--- a/style.css
+++ b/style.css
@@ -360,9 +360,8 @@ body {
     color: var(--nav-foreground);
     z-index: 1000;
     transform: translate(-50%, 0);
-    border: 1px solid transparent;
     backdrop-filter: blur(18px);
-    transition: background-color 0.6s ease, transform 0.6s ease-in-out, border-color 0.3s ease;
+    transition: background-color 0.6s ease, transform 0.6s ease-in-out;
 }
 
 .top-nav.hidden {
@@ -373,7 +372,6 @@ body {
 .top-nav.scrolled {
     background-color: var(--nav-background-scrolled);
     --nav-foreground: var(--nav-text-color-scrolled);
-    border-color: var(--border-color);
 }
 
 .nav-left,


### PR DESCRIPTION
## Summary
- remove the top navigation border styling so it no longer shows a border when scrolling

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68deaeaf15b883298fd9722e952d56aa