### PR TITLE
Refine hero spacing to remove global margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
                 ></iframe>
             </div>
             <div class="main-text">
-                <div class="intro">Hey, I'm Jason</div>
-                <div class="name">Software Engineer</div>
+                <h1 class="hero-title">Jason Zheng</h1>
+                <p class="hero-subtitle">Software Engineer</p>
             </div>
 
         </section>

--- a/index.html
+++ b/index.html
@@ -45,6 +45,15 @@
     <div class="scroll-wrapper">
         <!-- Hero -->
         <section id="hero" class="content hero-section">
+            <div class="hero-video" aria-hidden="true">
+                <iframe
+                    src="https://www.youtube.com/embed/qol_gS1txGs?autoplay=1&mute=1&controls=0&loop=1&playlist=qol_gS1txGs&modestbranding=1&playsinline=1&rel=0"
+                    title="Landing page background video"
+                    frameborder="0"
+                    allow="autoplay; fullscreen; picture-in-picture"
+                    allowfullscreen
+                ></iframe>
+            </div>
             <div class="main-text">
                 <div class="intro">Hey, I'm Jason</div>
                 <div class="name">Software Engineer</div>
@@ -52,7 +61,7 @@
 
         </section>
 
-        <section id="career">
+        <section id="career" class="section-container">
             <h2 class="section-title">Career</h2>
             <div class="career-entry">
                 <div class="career-left">
@@ -138,7 +147,7 @@
             </div>
         </section>
 
-        <section id="projects" class="projects-section">
+        <section id="projects" class="projects-section section-container">
             <h2 class="section-title">Projects</h2>
 
             <div class="project-entry">

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ body {
 
 
 .scroll-wrapper {
-    padding: 8rem 2.5rem 2rem;
+    padding: 0;
     position: relative;
     z-index: 1;
     max-width: 100%;
@@ -43,14 +43,51 @@ body {
     margin-right: auto;
 }
 
+.section-container {
+    width: 100%;
+    padding: 0 2.5rem;
+    margin: 0 auto;
+}
+
 /* Hero Section */
 .hero-section {
-    min-height: calc(100vh - 7rem);
+    min-height: 100vh;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     position: relative;
+    overflow: hidden;
+}
+
+.hero-section::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0%, rgba(0, 0, 0, 0.35) 60%, rgba(0, 0, 0, 0.65) 100%);
+    z-index: 0;
+}
+
+.hero-video {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+.hero-video iframe {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 177.78vh;
+    height: 100vh;
+    min-width: 100%;
+    min-height: 100%;
+    border: 0;
+    transform: translate(-50%, -50%);
 }
 
 
@@ -223,6 +260,9 @@ body {
     margin: auto 0;
     transition: opacity 0.2s ease, transform 0.2s ease;
     transform-origin: center;
+    position: relative;
+    z-index: 1;
+    color: #ffffff;
 }
 
 
@@ -237,14 +277,14 @@ body {
     font-size: clamp(1.5rem, 5vw + 0.2rem, 5rem);
     font-weight: 600;
     margin-bottom: 0.25rem;
-    color: var(--secondary-text);
+    color: rgba(255, 255, 255, 0.85);
 }
 
 
 .main-text .focus {
     font-size: clamp(1.4rem, 4vw + 0.2rem, 4.5rem);
     font-weight: 600;
-    color: var(--secondary-text);
+    color: rgba(255, 255, 255, 0.8);
 }
 
 /* Timeline Footer */
@@ -307,7 +347,7 @@ body {
 /* Top Navigation */
 .top-nav {
     position: fixed;
-    top: 28px;
+    top: 0;
     left: 50%;
     width: calc(100% - 5rem);
     display: flex;
@@ -387,7 +427,11 @@ body {
     }
 
     .scroll-wrapper {
-        padding-top: 2rem;
+        padding-top: 0;
+    }
+
+    .section-container {
+        padding: 0 1.5rem;
     }
 
     .hero-section {

--- a/style.css
+++ b/style.css
@@ -54,10 +54,11 @@ body {
     min-height: 100vh;
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    justify-content: flex-end;
+    align-items: flex-start;
     position: relative;
     overflow: hidden;
+    padding: clamp(5rem, 11vw, 8rem) clamp(1.5rem, 6vw, 5rem) clamp(7rem, 16vw, 11rem);
 }
 
 .hero-section::after {
@@ -253,38 +254,29 @@ body {
 
 /* Main Intro */
 .main-text {
-    line-height: 1.2;
+    line-height: 1.1;
     animation: fadeInUp 1s ease forwards;
     opacity: 0;
-    text-align: center;
-    margin: auto 0;
+    text-align: left;
+    margin: 0;
     transition: opacity 0.2s ease, transform 0.2s ease;
-    transform-origin: center;
     position: relative;
     z-index: 1;
     color: #ffffff;
+    max-width: min(48rem, 90vw);
 }
 
-
-.main-text .intro {
-    font-size: clamp(3rem, 8vw + 0.5rem, 8rem);
+.hero-title {
+    font-size: clamp(3.25rem, 9vw, 6.5rem);
     font-weight: 800;
-    margin-bottom: 0.5rem;
+    letter-spacing: -0.03em;
 }
 
-
-.main-text .name {
-    font-size: clamp(1.5rem, 5vw + 0.2rem, 5rem);
-    font-weight: 600;
-    margin-bottom: 0.25rem;
+.hero-subtitle {
+    font-size: clamp(1.5rem, 4vw, 3rem);
+    font-weight: 500;
     color: rgba(255, 255, 255, 0.85);
-}
-
-
-.main-text .focus {
-    font-size: clamp(1.4rem, 4vw + 0.2rem, 4.5rem);
-    font-weight: 600;
-    color: rgba(255, 255, 255, 0.8);
+    margin-top: clamp(0.75rem, 2vw, 1.5rem);
 }
 
 /* Timeline Footer */

--- a/style.css
+++ b/style.css
@@ -87,7 +87,7 @@ body {
     min-width: 100%;
     min-height: 100%;
     border: 0;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%) scale(1.2);
 }
 
 

--- a/style.css
+++ b/style.css
@@ -348,30 +348,31 @@ body {
 .top-nav {
     position: fixed;
     top: 0;
-    left: 50%;
-    width: calc(100% - 5rem);
+    left: 0;
+    width: 100%;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 12px;
+    padding: 1.5rem 2.5rem;
     margin: 0;
-    --nav-foreground: var(--text-color);
-    background-color: var(--nav-background);
+    --nav-foreground: #f5f7ff;
+    background-color: transparent;
     color: var(--nav-foreground);
     z-index: 1000;
-    transform: translate(-50%, 0);
-    backdrop-filter: blur(18px);
-    transition: background-color 0.6s ease, transform 0.6s ease-in-out;
+    transform: translateY(0);
+    transition: background-color 0.6s ease, transform 0.6s ease-in-out, color 0.6s ease;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
 }
 
 .top-nav.hidden {
-    transform: translate(-50%, -180%);
+    transform: translateY(-180%);
     pointer-events: none;
 }
 
 .top-nav.scrolled {
     background-color: var(--nav-background-scrolled);
     --nav-foreground: var(--nav-text-color-scrolled);
+    text-shadow: none;
 }
 
 .nav-left,


### PR DESCRIPTION
## Summary
- remove the global scroll wrapper padding so the hero video can reach the viewport edges without a surrounding margin
- add a reusable section container class to restore horizontal padding for the content sections on desktop and mobile breakpoints

## Testing
- Manual QA: Loaded http://localhost:8000 to confirm the hero section spans edge-to-edge while other sections retain readable padding


------
https://chatgpt.com/codex/tasks/task_e_68defe635a1083298e7cb55cc4f95305