### PR TITLE
Adjust hero text positioning

### DIFF
--- a/style.css
+++ b/style.css
@@ -58,7 +58,7 @@ body {
     align-items: flex-start;
     position: relative;
     overflow: hidden;
-    padding: clamp(5rem, 11vw, 8rem) clamp(1.5rem, 6vw, 5rem) clamp(7rem, 16vw, 11rem);
+    padding: clamp(4rem, 10vw, 6rem) clamp(1.5rem, 6vw, 5rem) clamp(2.5rem, 8vw, 4rem);
 }
 
 .hero-section::after {
@@ -259,6 +259,8 @@ body {
     opacity: 0;
     text-align: left;
     margin: 0;
+    margin-top: auto;
+    align-self: flex-start;
     transition: opacity 0.2s ease, transform 0.2s ease;
     position: relative;
     z-index: 1;
@@ -431,8 +433,9 @@ body {
         min-height: calc(100vh - 4rem);
         display: flex;
         flex-direction: column;
-        justify-content: center;
-        align-items: center;
+        justify-content: flex-end;
+        align-items: flex-start;
+        padding: clamp(3rem, 12vw, 5rem) 1.5rem clamp(2rem, 10vw, 3rem);
     }
 
     .hamburger-icon {


### PR DESCRIPTION
## Summary
- reposition hero text block to stay anchored at the bottom left of the landing section
- fine-tune hero padding for desktop and mobile views to support the new placement

## Testing
- visual inspection

------
https://chatgpt.com/codex/tasks/task_e_68e0854f28e0832996933c163d14346d