### PR TITLE
Add 28px page padding while keeping hero full-width

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ body {
 
 
 .scroll-wrapper {
-    padding: 0;
+    padding: 28px;
     position: relative;
     z-index: 1;
     max-width: 100%;
@@ -59,6 +59,7 @@ body {
     position: relative;
     overflow: hidden;
     padding: clamp(4rem, 10vw, 6rem) clamp(1.5rem, 6vw, 5rem) clamp(2.5rem, 8vw, 4rem);
+    margin: -28px -28px 0;
 }
 
 .hero-section::after {


### PR DESCRIPTION
## Summary
- add a consistent 28px padding around the main scrollable content
- offset the hero section margins so the video and fallback image continue to span edge-to-edge

## Testing
- Not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68e09003834883299254f25d61f5d3bd