### PR TITLE
Add hero video fallback image handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,11 @@
         <!-- Hero -->
         <section id="hero" class="content hero-section">
             <div class="hero-video" aria-hidden="true">
+                <img
+                    class="hero-fallback"
+                    src="images/hero-fallback.jpg"
+                    alt="Abstract dark gradient background"
+                />
                 <iframe
                     src="https://www.youtube.com/embed/qol_gS1txGs?autoplay=1&mute=1&controls=0&loop=1&playlist=qol_gS1txGs&modestbranding=1&playsinline=1&rel=0"
                     title="Landing page background video"
@@ -60,7 +65,6 @@
             </div>
 
         </section>
-
         <section id="career" class="section-container">
             <h2 class="section-title">Career</h2>
             <div class="career-entry">
@@ -272,6 +276,17 @@
         window.onload = () => {
             document.getElementById("icon-close").style.display = "none";
         };
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const heroVideo = document.querySelector('.hero-video');
+            const iframe = heroVideo ? heroVideo.querySelector('iframe') : null;
+
+            if (heroVideo && iframe) {
+                iframe.addEventListener('load', () => {
+                    heroVideo.classList.add('video-loaded');
+                });
+            }
+        });
 
         const nav = document.querySelector('.top-nav');
         const heroSection = document.getElementById('hero');

--- a/style.css
+++ b/style.css
@@ -75,10 +75,20 @@ body {
     inset: 0;
     width: 100%;
     height: 100%;
-    background: #02030b url("images/hero-fallback.jpg") center / cover no-repeat;
+    background: #02030b;
     z-index: -1;
     pointer-events: none;
     overflow: hidden;
+}
+
+.hero-video .hero-fallback {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: 0;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
 }
 
 .hero-video iframe {
@@ -91,6 +101,12 @@ body {
     min-height: 100%;
     border: 0;
     transform: translate(-50%, -50%) scale(1.2);
+    z-index: 1;
+}
+
+.hero-video.video-loaded .hero-fallback {
+    opacity: 0;
+    visibility: hidden;
 }
 
 


### PR DESCRIPTION
## Summary
- add a fallback image to the hero video embed
- layer the fallback image behind the iframe and hide it after the video loads
- toggle the fallback visibility with a small script tied to the iframe load event

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1de2341408329acec34078f7b3f5a