### PR TITLE
Add Socials dropdown to navigation bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,19 @@
         <div class="nav-left">
             <a href="#career">Career</a>
             <a href="#projects">Projects</a>
-            <a href="#skills">Skills</a>
             <a href="#">Organizations</a>
+            <div class="nav-dropdown">
+                <button class="dropdown-toggle" type="button" aria-haspopup="true">
+                    Socials
+                    <span class="dropdown-icon" aria-hidden="true"></span>
+                </button>
+                <div class="dropdown-menu" role="menu">
+                    <a href="https://www.linkedin.com/in/jzheng39/" target="_blank" role="menuitem">LinkedIn</a>
+                    <a href="https://github.com/M1ght1203" target="_blank" role="menuitem">GitHub</a>
+                </div>
+            </div>
         </div>
         <div class="nav-right">
-            <a href="https://www.linkedin.com/in/jzheng39/" target="_blank">LinkedIn</a>
-            <a href="https://github.com/M1ght1203" target="_blank">GitHub</a>
             <a href="resume/resume.pdf" target="_blank" download>Resume</a>
         </div>
     </nav>
@@ -252,8 +259,8 @@
     <div class="mobile-menu" id="mobileMenu">
         <a href="#career">Career</a>
         <a href="#projects">Projects</a>
-        <a href="#skills">Skills</a>
         <a href="#">Organizations</a>
+        <span class="mobile-menu-heading">Socials</span>
         <a href="https://www.linkedin.com/in/jzheng39/" target="_blank">LinkedIn</a>
         <a href="https://github.com/M1ght1203" target="_blank">GitHub</a>
         <a href="resume/resume.pdf" target="_blank" download>Resume</a>

--- a/style.css
+++ b/style.css
@@ -394,6 +394,101 @@ body {
     align-items: center;
 }
 
+.nav-left .nav-dropdown {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.nav-left .dropdown-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: clamp(0.8rem, 1vw, 1rem);
+    font-family: inherit;
+    letter-spacing: 0.1em;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    text-transform: uppercase;
+    padding: 0;
+}
+
+.nav-left .dropdown-toggle:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 4px;
+}
+
+.nav-left .dropdown-icon {
+    position: relative;
+    width: 0.55rem;
+    height: 0.55rem;
+    display: inline-block;
+}
+
+.nav-left .dropdown-icon::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0.45rem;
+    height: 0.45rem;
+    border-right: 1px solid currentColor;
+    border-bottom: 1px solid currentColor;
+    transform: translate(-50%, -65%) rotate(45deg);
+    transition: transform 0.2s ease;
+}
+
+.nav-left .nav-dropdown:hover .dropdown-icon::before,
+.nav-left .nav-dropdown:focus-within .dropdown-icon::before {
+    transform: translate(-50%, -35%) rotate(225deg);
+}
+
+.nav-left .dropdown-menu {
+    position: absolute;
+    top: calc(100% + 1.25rem);
+    left: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.25rem 1.75rem;
+    min-width: 180px;
+    background: rgba(12, 17, 35, 0.92);
+    color: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.28);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(12px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    backdrop-filter: blur(12px);
+}
+
+.top-nav.scrolled .nav-left .dropdown-menu {
+    background: rgba(255, 255, 255, 0.95);
+    color: var(--text-color);
+}
+
+.nav-left .nav-dropdown:hover .dropdown-menu,
+.nav-left .nav-dropdown:focus-within .dropdown-menu {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
+.nav-left .dropdown-menu a {
+    color: inherit;
+    text-decoration: none;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+}
+
+.nav-left .dropdown-menu a:hover,
+.nav-left .dropdown-menu a:focus {
+    text-decoration: underline;
+}
+
 .top-nav a {
     font-size: clamp(0.8rem, 1vw, 1rem);
     color: inherit;
@@ -492,6 +587,14 @@ body {
         text-decoration: none;
         margin: 1rem 0;
         font-size: 1.1rem;
+    }
+
+    .mobile-menu-heading {
+        margin-top: 1.5rem;
+        font-size: 0.85rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--secondary-text);
     }
 
     .mobile-menu.show {


### PR DESCRIPTION
## Summary
- remove the unused Skills link from the desktop and mobile navigation menus
- add a Socials dropdown to the primary navigation with LinkedIn and GitHub links
- update mobile navigation to group social links under a dedicated heading

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4617d7a4c8329a18220e342ea684e