### PR TITLE
Adjust navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,11 @@
         <div class="nav-left">
             <a href="#career">Career</a>
             <a href="#projects">Projects</a>
-            <a href="#skills">Skills</a>
             <a href="#">Organizations</a>
-        </div>
-        <div class="nav-right">
             <a href="https://www.linkedin.com/in/jzheng39/" target="_blank">LinkedIn</a>
             <a href="https://github.com/M1ght1203" target="_blank">GitHub</a>
+        </div>
+        <div class="nav-right">
             <a href="resume/resume.pdf" target="_blank" download>Resume</a>
         </div>
     </nav>
@@ -252,7 +251,6 @@
     <div class="mobile-menu" id="mobileMenu">
         <a href="#career">Career</a>
         <a href="#projects">Projects</a>
-        <a href="#skills">Skills</a>
         <a href="#">Organizations</a>
         <a href="https://www.linkedin.com/in/jzheng39/" target="_blank">LinkedIn</a>
         <a href="https://github.com/M1ght1203" target="_blank">GitHub</a>


### PR DESCRIPTION
## Summary
- remove the Skills link from the primary and mobile navigation menus
- move the LinkedIn and GitHub links to the left navigation group to sit with the other section links
- keep the Resume download alone on the right side of the navigation bar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e47fc6e39883298eb36d0cb86f0b96