### PR TITLE
Style resume button with white background

### DIFF
--- a/style.css
+++ b/style.css
@@ -409,17 +409,17 @@ body {
     padding: 0.6rem 1.4rem;
     background-color: #ffffff;
     color: #000000;
-    border: 1px solid rgba(0, 0, 0, 0.12);
+    border: none;
     border-radius: 0;
-    box-shadow: 0 4px 10px rgba(15, 23, 42, 0.12);
-    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .nav-right a:hover,
 .nav-right a:focus-visible {
     background-color: #f5f5f5;
     color: #000000;
-    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.18);
+    box-shadow: none;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -422,6 +422,17 @@ body {
     box-shadow: none;
 }
 
+.top-nav.scrolled .nav-right a {
+    background-color: #000000;
+    color: #ffffff;
+}
+
+.top-nav.scrolled .nav-right a:hover,
+.top-nav.scrolled .nav-right a:focus-visible {
+    background-color: #111111;
+    color: #ffffff;
+}
+
 
 /* Project Button */
 .project-button {

--- a/style.css
+++ b/style.css
@@ -402,6 +402,26 @@ body {
     opacity: 1;
 }
 
+.nav-right a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.6rem 1.4rem;
+    background-color: #ffffff;
+    color: #000000;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 0;
+    box-shadow: 0 4px 10px rgba(15, 23, 42, 0.12);
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav-right a:hover,
+.nav-right a:focus-visible {
+    background-color: #f5f5f5;
+    color: #000000;
+    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.18);
+}
+
 
 /* Project Button */
 .project-button {


### PR DESCRIPTION
## Summary
- give the resume navigation link a white background with square corners
- add hover and focus states to support the updated styling

## Testing
- not run (not run tests)

------
https://chatgpt.com/codex/tasks/task_e_68e563781e908329a763782be21597b5