### PR TITLE
Expand mobile menu to full-screen overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,11 +261,13 @@
         function toggleMenu() {
             const menu = document.getElementById("mobileMenu");
             const backdrop = document.querySelector(".mobile-backdrop");
+            const hamburgerToggle = document.querySelector(".hamburger-icon");
             const iconHamburger = document.getElementById("icon-hamburger");
             const iconClose = document.getElementById("icon-close");
 
             const isOpen = menu.classList.toggle("show");
             backdrop.classList.toggle("visible");
+            hamburgerToggle.classList.toggle("open", isOpen);
             iconHamburger.style.display = isOpen ? "none" : "block";
             iconClose.style.display = isOpen ? "block" : "none";
         }
@@ -273,6 +275,7 @@
         // Initial state
         window.onload = () => {
             document.getElementById("icon-close").style.display = "none";
+            document.querySelector(".hamburger-icon").classList.remove("open");
         };
 
         document.addEventListener('DOMContentLoaded', () => {

--- a/style.css
+++ b/style.css
@@ -520,6 +520,7 @@ body {
         height: 100vh;
         background-color: var(--mobile-menu-bg);
         padding: 3rem 2rem;
+        padding-top: 3.75rem;
         transform: translateY(-100%);
         transition: transform 0.3s ease;
         z-index: 1000;

--- a/style.css
+++ b/style.css
@@ -510,8 +510,8 @@ body {
     .mobile-menu {
         display: flex;
         flex-direction: column;
-        align-items: center;
-        justify-content: center;
+        align-items: flex-start;
+        justify-content: flex-start;
         gap: 1.5rem;
         position: fixed;
         top: 0;
@@ -531,6 +531,8 @@ body {
         text-decoration: none;
         margin: 0;
         font-size: 1.2rem;
+        width: 100%;
+        text-align: left;
     }
 
     .mobile-menu.show {

--- a/style.css
+++ b/style.css
@@ -511,13 +511,12 @@ body {
         gap: 1.5rem;
         position: fixed;
         top: 0;
-        right: 0;
-        bottom: 0;
+        left: 0;
         width: 100vw;
         height: 100vh;
         background-color: var(--mobile-menu-bg);
         padding: 3rem 2rem;
-        transform: translateX(100%);
+        transform: translateY(-100%);
         transition: transform 0.3s ease;
         z-index: 1000;
         overflow-y: auto;
@@ -531,7 +530,7 @@ body {
     }
 
     .mobile-menu.show {
-        transform: translateX(0);
+        transform: translateY(0);
     }
 
     .mobile-backdrop {

--- a/style.css
+++ b/style.css
@@ -493,7 +493,7 @@ body {
         right: 1.2rem;
         z-index: 1001;
         cursor: pointer;
-        color: var(--text-color);
+        color: #ffffff;
         display: block;
     }
 

--- a/style.css
+++ b/style.css
@@ -497,6 +497,10 @@ body {
         display: block;
     }
 
+    .hamburger-icon.open {
+        color: #000000;
+    }
+
     .hamburger-icon svg {
         width: 30px;
         height: 30px;

--- a/style.css
+++ b/style.css
@@ -506,27 +506,32 @@ body {
     .mobile-menu {
         display: flex;
         flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 1.5rem;
         position: fixed;
         top: 0;
-        right: -250px;
-        width: 200px;
+        right: 0;
+        bottom: 0;
+        width: 100vw;
         height: 100vh;
         background-color: var(--mobile-menu-bg);
-        border-left: 1px solid var(--border-color);
-        padding: 2rem 3rem;
-        transition: right 0.3s ease;
+        padding: 3rem 2rem;
+        transform: translateX(100%);
+        transition: transform 0.3s ease;
         z-index: 1000;
+        overflow-y: auto;
     }
 
     .mobile-menu a {
         color: var(--text-color);
         text-decoration: none;
-        margin: 1rem 0;
-        font-size: 1.1rem;
+        margin: 0;
+        font-size: 1.2rem;
     }
 
     .mobile-menu.show {
-        right: 0;
+        transform: translateX(0);
     }
 
     .mobile-backdrop {


### PR DESCRIPTION
## Summary
- update the mobile navigation drawer to cover the entire viewport when opened
- center menu links within the overlay and ensure smooth slide-in animation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5832cd35c8329be3a5b024e194f8d