### PR TITLE
Adjust mobile resume button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
         <a href="#">Organizations</a>
         <a href="https://www.linkedin.com/in/jzheng39/" target="_blank">LinkedIn</a>
         <a href="https://github.com/M1ght1203" target="_blank">GitHub</a>
-        <a href="resume/resume.pdf" target="_blank" download>Resume</a>
+        <a class="mobile-resume" href="resume/resume.pdf" target="_blank" download>Resume</a>
     </div>
 
     <script>

--- a/style.css
+++ b/style.css
@@ -536,6 +536,27 @@ body {
         text-align: left;
     }
 
+    .mobile-menu .mobile-resume {
+        margin-top: auto;
+        align-self: center;
+        padding: 0.6rem 1.4rem;
+        background-color: #000000;
+        color: #ffffff;
+        border: none;
+        border-radius: 0;
+        text-align: center;
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        transition: background-color 0.2s ease, color 0.2s ease;
+    }
+
+    .mobile-menu .mobile-resume:hover,
+    .mobile-menu .mobile-resume:focus-visible {
+        background-color: #111111;
+        color: #ffffff;
+    }
+
     .mobile-menu.show {
         transform: translateY(0);
     }


### PR DESCRIPTION
## Summary
- add a dedicated class to the mobile resume link so it can be styled independently
- update the mobile navigation styles so the resume button sits at the bottom, centers, and matches the desktop button styling with a black background

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5b7a2ec8c8329b2c7f56157b4138a