### PR TITLE
Adjust mobile carousel height on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -522,6 +522,12 @@ body {
         display: none;
     }
 
+    .carousel-item {
+        height: 66vh;
+        max-height: 66vh;
+        aspect-ratio: auto;
+    }
+
     .scroll-wrapper {
         padding-top: 0;
     }


### PR DESCRIPTION
## Summary
- set the carousel item height to fill roughly two-thirds of the viewport on mobile breakpoints by overriding its aspect ratio

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fa5d27bcbc8329b065d171abb2e15b