### PR TITLE
Refine career carousel overlay layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,12 +147,42 @@
             <h2 class="section-title">Career</h2>
             <div class="image-carousel" role="list" id="careerCarousel">
                 <div class="carousel-item" role="listitem">
+                    <div class="carousel-overlay" aria-hidden="false">
+                        <p class="overlay-label">Internship</p>
+                        <h3 class="overlay-title">Electromagnetic Compatibility Testing</h3>
+                        <p class="overlay-subtitle">L3Harris · Melbourne, FL</p>
+                        <p class="overlay-date">August 2025</p>
+                        <p class="overlay-description">
+                            Supported avionics testing campaigns to safeguard onboard systems from signal interference
+                            during integration and launch readiness.
+                        </p>
+                    </div>
                     <img src="images/L3Harris-1.jpg" alt="L3Harris Tactical Communication" />
                 </div>
                 <div class="carousel-item" role="listitem">
+                    <div class="carousel-overlay" aria-hidden="false">
+                        <p class="overlay-label">Automation</p>
+                        <h3 class="overlay-title">Pricing Intelligence Platform</h3>
+                        <p class="overlay-subtitle">L3Harris · Melbourne, FL</p>
+                        <p class="overlay-date">June 2024</p>
+                        <p class="overlay-description">
+                            Delivered a WPF-based CPQ solution that accelerated quoting workflows and introduced versioned
+                            pricing governance across teams.
+                        </p>
+                    </div>
                     <img src="images/L3Harris-2.jpg" alt="L3Harris Tactical Communication" />
                 </div>
                 <div class="carousel-item" role="listitem">
+                    <div class="carousel-overlay" aria-hidden="false">
+                        <p class="overlay-label">Operations</p>
+                        <h3 class="overlay-title">Logistics Optimization</h3>
+                        <p class="overlay-subtitle">C U Plastic · Orlando, FL</p>
+                        <p class="overlay-date">May 2024</p>
+                        <p class="overlay-description">
+                            Introduced cross-department workflows and staging strategies that improved throughput and
+                            reduced load times by 25%.
+                        </p>
+                    </div>
                     <img src="images/CU-Plastic.jpg" alt="C U Plastic" />
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -175,7 +175,7 @@ body {
     bottom: var(--carousel-gap);
     padding: clamp(1rem, 2.5vw, 1.75rem);
     max-width: min(24rem, 80%);
-    background: rgba(6, 9, 16, 0.9);
+    background: rgba(6, 9, 16, 0.82);
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 0;
     box-shadow: 0 18px 35px rgba(3, 5, 10, 0.45);

--- a/style.css
+++ b/style.css
@@ -120,8 +120,9 @@ body {
 }
 
 .image-carousel {
+    --carousel-gap: 1.5rem;
     display: flex;
-    gap: 1.5rem;
+    gap: var(--carousel-gap);
     overflow-x: auto;
     padding-bottom: 1rem;
     scroll-snap-type: x mandatory;
@@ -170,8 +171,8 @@ body {
 
 .carousel-overlay {
     position: absolute;
-    left: clamp(0.65rem, 2.5vw, 1.75rem);
-    bottom: clamp(0.65rem, 2.5vw, 1.75rem);
+    left: var(--carousel-gap);
+    bottom: var(--carousel-gap);
     padding: clamp(1rem, 2.5vw, 1.75rem);
     max-width: min(24rem, 80%);
     background: rgba(6, 9, 16, 0.9);
@@ -226,9 +227,13 @@ body {
         max-width: 85vw;
     }
 
+    .image-carousel {
+        --carousel-gap: clamp(0.75rem, 4vw, 1.25rem);
+    }
+
     .carousel-overlay {
-        left: clamp(0.5rem, 3.5vw, 1.25rem);
-        right: clamp(0.5rem, 3.5vw, 1.25rem);
+        left: var(--carousel-gap);
+        right: var(--carousel-gap);
         max-width: none;
         border-radius: 12px;
         padding: clamp(0.85rem, 4vw, 1.25rem);

--- a/style.css
+++ b/style.css
@@ -146,6 +146,8 @@ body {
     aspect-ratio: 16 / 9;
     background: transparent;
     border-radius: 0;
+    position: relative;
+    overflow: hidden;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -164,6 +166,78 @@ body {
     object-fit: cover;
     border-radius: inherit;
     pointer-events: none;
+}
+
+.carousel-overlay {
+    position: absolute;
+    left: clamp(1rem, 3vw, 2.5rem);
+    bottom: clamp(1rem, 3vw, 2.5rem);
+    padding: clamp(1rem, 2.5vw, 1.75rem);
+    max-width: min(24rem, 80%);
+    background: rgba(6, 9, 16, 0.9);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    box-shadow: 0 18px 35px rgba(3, 5, 10, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    color: #f8f9fb;
+    pointer-events: none;
+}
+
+.overlay-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.7);
+    margin: 0;
+}
+
+.overlay-title {
+    font-size: clamp(1.1rem, 2.2vw, 1.55rem);
+    font-weight: 700;
+    line-height: 1.2;
+    margin: 0;
+}
+
+.overlay-subtitle,
+.overlay-date,
+.overlay-description {
+    font-size: clamp(0.85rem, 1.6vw, 0.95rem);
+    line-height: 1.5;
+    margin: 0;
+    font-weight: 400;
+}
+
+.overlay-date {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.overlay-description {
+    margin-top: 0.35rem;
+    max-width: none;
+}
+
+@media (max-width: 640px) {
+    .carousel-item {
+        flex: 0 0 85vw;
+        max-width: 85vw;
+    }
+
+    .carousel-overlay {
+        left: clamp(0.75rem, 4vw, 1.5rem);
+        right: clamp(0.75rem, 4vw, 1.5rem);
+        max-width: none;
+        border-radius: 12px;
+        padding: clamp(0.85rem, 4vw, 1.25rem);
+    }
+
+    .overlay-label {
+        font-size: 0.65rem;
+        letter-spacing: 0.22em;
+    }
 }
 
 .image-carousel.is-free-scroll {
@@ -526,6 +600,17 @@ body {
         height: 66vh;
         max-height: 66vh;
         aspect-ratio: auto;
+    }
+
+    .carousel-overlay {
+        inset: 0;
+        padding: clamp(1rem, 6vw, 2.5rem);
+        gap: 0.5rem;
+        background: linear-gradient(180deg, rgba(5, 8, 15, 0.9) 0%, rgba(5, 8, 15, 0.7) 65%, rgba(5, 8, 15, 0) 100%);
+    }
+
+    .overlay-description {
+        max-width: 100%;
     }
 
     .scroll-wrapper {

--- a/style.css
+++ b/style.css
@@ -177,7 +177,7 @@ body {
     max-width: min(24rem, 80%);
     background: rgba(6, 9, 16, 0.9);
     border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 14px;
+    border-radius: 0;
     box-shadow: 0 18px 35px rgba(3, 5, 10, 0.45);
     display: flex;
     flex-direction: column;
@@ -235,7 +235,7 @@ body {
         left: var(--carousel-gap);
         right: var(--carousel-gap);
         max-width: none;
-        border-radius: 12px;
+        border-radius: 0;
         padding: clamp(0.85rem, 4vw, 1.25rem);
     }
 

--- a/style.css
+++ b/style.css
@@ -170,8 +170,8 @@ body {
 
 .carousel-overlay {
     position: absolute;
-    left: clamp(1rem, 3vw, 2.5rem);
-    bottom: clamp(1rem, 3vw, 2.5rem);
+    left: clamp(0.65rem, 2.5vw, 1.75rem);
+    bottom: clamp(0.65rem, 2.5vw, 1.75rem);
     padding: clamp(1rem, 2.5vw, 1.75rem);
     max-width: min(24rem, 80%);
     background: rgba(6, 9, 16, 0.9);
@@ -227,8 +227,8 @@ body {
     }
 
     .carousel-overlay {
-        left: clamp(0.75rem, 4vw, 1.5rem);
-        right: clamp(0.75rem, 4vw, 1.5rem);
+        left: clamp(0.5rem, 3.5vw, 1.25rem);
+        right: clamp(0.5rem, 3.5vw, 1.25rem);
         max-width: none;
         border-radius: 12px;
         padding: clamp(0.85rem, 4vw, 1.25rem);


### PR DESCRIPTION
## Summary
- anchor carousel overlay panels to the bottom-left of each image with a contained info box treatment
- adjust overlay typography to align with the site's Inter font weights and spacing
- refine responsive behavior for the overlays on smaller screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa5ea375808329a8f62460a4986088